### PR TITLE
Fix progress load order and sanitize output files

### DIFF
--- a/imdb_import_from_csv.sh
+++ b/imdb_import_from_csv.sh
@@ -205,10 +205,21 @@ for ID in "${IMDB_IDS[@]}"; do
   fi
 
   YOUR_RATING="${RATING_MAP[$ID]}"
+
+  SAFE_TITLE=$(echo "$TITLE" | tr '/\\' '__' | tr -d '":*?<>|\\')
+
+  if [[ "$TYPE" == "series" ]]; then
+    FINAL_OUTPUT_DIR="/Users/joelplourde/Documents/Obsidian/Vaults/Jojo/04 - Entertainment/01 - TV/01 - TV Shows"
+  else
+    FINAL_OUTPUT_DIR="/Users/joelplourde/Documents/Obsidian/Vaults/Jojo/04 - Entertainment/01 - TV/02 - Movies"
+  fi
+
+  FILENAME="${FINAL_OUTPUT_DIR}/${SAFE_TITLE}.md"
+
   # Attempt to preserve existing progress status from previously written files
   # Determine progress value
   if [[ -f "$FILENAME" ]]; then
-    PROGRESS_VALUE=$(grep '^progress:' "$FILENAME" | sed 's/progress: "\(.*\)"/\1/')
+    PROGRESS_VALUE=$(awk -F'"' '/^progress:/ {print $2; exit}' "$FILENAME")
   fi
 
   # Set progress status based on context:
@@ -225,17 +236,7 @@ for ID in "${IMDB_IDS[@]}"; do
     fi
   fi
 
-  SAFE_TITLE=$(echo "$TITLE" | tr '/' '_' | tr -d '":*?<>|')
-
-  if [[ "$TYPE" == "series" ]]; then
-    FINAL_OUTPUT_DIR="/Users/joelplourde/Documents/Obsidian/Vaults/Jojo/04 - Entertainment/01 - TV/01 - TV Shows"
-  else
-    FINAL_OUTPUT_DIR="/Users/joelplourde/Documents/Obsidian/Vaults/Jojo/04 - Entertainment/01 - TV/02 - Movies"
-  fi
-
   mkdir -p "$FINAL_OUTPUT_DIR"
-
-  FILENAME="${FINAL_OUTPUT_DIR}/${TITLE}.md"
 
   # --- Markdown File Generation ---
   # Format all retrieved data into a Markdown front matter and body.


### PR DESCRIPTION
## Summary
- Compute output file path earlier and use sanitized titles
- Preserve existing `progress` field by loading file before assigning defaults
- Replace path separators and strip invalid characters in titles
- Parse existing `progress` values with `awk`

## Testing
- `bash -n imdb_import_from_csv.sh`
- `shellcheck imdb_import_from_csv.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896099663ec83299b0d890ad441254f