### PR TITLE
docs: fix IMDb capitalization in output directory comment

### DIFF
--- a/imdb_import_from_csv.sh
+++ b/imdb_import_from_csv.sh
@@ -25,7 +25,7 @@ IS_WATCHLIST_MODE=false
 CACHE_DIR="$HOME/.omdb_cache"
 CACHE_EXPIRY_DAYS=30
 mkdir -p "$CACHE_DIR"
-OUTPUT_DIR="/Users/my_user/Documents/Obsidian/Vaults/Jojo/04 - Entertainment/01 - TV" # Obsidian Vault Location for the IMDB entries
+OUTPUT_DIR="/Users/my_user/Documents/Obsidian/Vaults/Jojo/04 - Entertainment/01 - TV" # Obsidian Vault Location for the IMDb entries
 # -------------------------------------------
 
 echo "🚀 Script started using Bash version: $BASH_VERSION"


### PR DESCRIPTION
## Summary
- correct IMDb capitalization in output directory comment of `imdb_import_from_csv.sh`

## Testing
- `bash -n imdb_import_from_csv.sh`

------
https://chatgpt.com/codex/tasks/task_e_68961587300c8329b9a7c7c899a4f92b